### PR TITLE
eve: Run pre-merge on release/* branches

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -74,7 +74,7 @@ models:
       alwaysRun: True
 
 branches:
-  user/*, feature/*, improvement/*, bugfix/*, documentation/*:
+  user/*, feature/*, improvement/*, bugfix/*, documentation/*, release/*:
     stage: pre-merge
 
 stages:


### PR DESCRIPTION
This is needed to automatically trigger build of release/* in CI.